### PR TITLE
Fixes for "Copper Slave" and "Hamazing" demos (thx to Robinsonb5)

### DIFF
--- a/src/fpga/core/amiga/agnus_bitplanedma.v
+++ b/src/fpga/core/amiga/agnus_bitplanedma.v
@@ -66,8 +66,8 @@ wire [ 8: 2] ddfdiff;
 wire [ 8: 2] ddfdiff_masked;
 reg  [15: 1] bpl1mod;             // modulo for odd bitplanes
 reg  [15: 1] bpl2mod;             // modulo for even bitplanes
-wire [15: 1] bpl1mod_bscan;       // modulo for odd bitplanes, adjusted for bitplane scandoubling
-wire [15: 1] bpl2mod_bscan;       // modulo for even bitplanes, adjusted for bitplane scandoubling
+reg [15: 1] bpl1mod_bscan;        // modulo for odd bitplanes, adjusted for bitplane scandoubling - AMR, and extra delay, for RAMJAM: Copperslave.
+reg [15: 1] bpl2mod_bscan;        // modulo for even bitplanes, adjusted for bitplane scandoubling
 
 reg  [ 5: 0] bplcon0;             // bitplane control (SHRES, HIRES and BPU bits)
 reg  [ 5: 0] bplcon0_delayed;     // delayed bplcon0 (compatibility)
@@ -472,8 +472,13 @@ end
 assign dma = (ddfrun) && dmaena_delayed[1] && hpos[0] && (plane[4:0] < {1'b0,bpu[3:0]}) ? 1'b1 : 1'b0;
 
 // adjust BPLxMOD for scandoubling
-assign bpl1mod_bscan = fmode[14] ? ((vdiwstrt[0] ^ vpos[0]) ? bpl2mod : bpl1mod) : bpl1mod;
-assign bpl2mod_bscan = fmode[14] ? ((vdiwstrt[0] ^ vpos[0]) ? bpl2mod : bpl1mod) : bpl2mod;
+// AMR - incorporate a delay too
+always @(posedge clk) begin
+	if (clk7_en && hpos[0]) begin
+		bpl1mod_bscan <= fmode[14] ? ((vdiwstrt[0] ^ vpos[0]) ? bpl2mod : bpl1mod) : bpl1mod;
+		bpl2mod_bscan <= fmode[14] ? ((vdiwstrt[0] ^ vpos[0]) ? bpl2mod : bpl1mod) : bpl2mod;
+	end
+end
 
 // dma pointer arithmetic unit
 always @ (*) begin

--- a/src/fpga/core/amiga/denise.v
+++ b/src/fpga/core/amiga/denise.v
@@ -330,14 +330,18 @@ denise_bitplanes bplm0
   .bpldata(bpldata_out)
 );
 
-assign bpldata[1] = l_bpu > 0 ? bpldata_out[1] : 1'b0;
-assign bpldata[2] = l_bpu > 1 ? bpldata_out[2] : 1'b0;
-assign bpldata[3] = l_bpu > 2 ? bpldata_out[3] : 1'b0;
-assign bpldata[4] = l_bpu > 3 ? bpldata_out[4] : 1'b0;
-assign bpldata[5] = l_bpu > 4 ? bpldata_out[5] : 1'b0;
-assign bpldata[6] = l_bpu > 5 ? bpldata_out[6] : 1'b0;
-assign bpldata[7] = l_bpu > 6 ? bpldata_out[7] : 1'b0;
-assign bpldata[8] = l_bpu > 7 ? bpldata_out[8] : 1'b0;
+// AMR - mask bpldata against window_ena, so that the HAM generator always receives
+// the background colour outside the display window, to prevent the HAM generator
+// reacting to pixels scrolled off the left hand side of the screen.
+// Fixes Desire: Hamazing's "Hambarger" scene.
+assign bpldata[1] = window_ena && (l_bpu > 0) ? bpldata_out[1] : 1'b0;
+assign bpldata[2] = window_ena && (l_bpu > 1) ? bpldata_out[2] : 1'b0;
+assign bpldata[3] = window_ena && (l_bpu > 2) ? bpldata_out[3] : 1'b0;
+assign bpldata[4] = window_ena && (l_bpu > 3) ? bpldata_out[4] : 1'b0;
+assign bpldata[5] = window_ena && (l_bpu > 4) ? bpldata_out[5] : 1'b0;
+assign bpldata[6] = window_ena && (l_bpu > 5) ? bpldata_out[6] : 1'b0;
+assign bpldata[7] = window_ena && (l_bpu > 6) ? bpldata_out[7] : 1'b0;
+assign bpldata[8] = window_ena && (l_bpu > 7) ? bpldata_out[8] : 1'b0;
 
 // instantiate playfield module
 denise_playfields plfm0


### PR DESCRIPTION
Fixed modulo problem in RAMJAM Copperslave. HAM generator's input now masked by DIW (fixes Desire - Hamazing Hambarger effect). Ported from MiST.

Backported from MiSTer core. Thanks to tdelage26 and all involved.